### PR TITLE
fix: ensure proper type casting for half_width calculation in Camera …

### DIFF
--- a/src/DataTypes/Camera.hpp
+++ b/src/DataTypes/Camera.hpp
@@ -23,7 +23,7 @@ public:
 
         float theta = _fov * M_PI / 180.0f;
         float half_height = tan(theta / 2);
-        float half_width = (_width / _height) * half_height;
+        float half_width = (static_cast<float>(_width) / static_cast<float>(_height)) * half_height;
 
         Vec3 lower_left_corner = _position + forward - half_width * right - half_height * up;
         Vec3 horizontal = 2 * half_width * right;


### PR DESCRIPTION
…class

## What does this PR do?

Fix aspect ratio calculations

## Related issue

Closes #54 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
