### PR TITLE
Fix help display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(raytracer
     src/factories/ShapeFactory.cpp
     src/factories/MaterialFactory.cpp
     src/factories/LightFactory.cpp
+    src/utils/HelpDisplay.cpp
 )
 
 target_include_directories(raytracer PRIVATE

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,11 @@
+Usage: raytracer <input_file>
+
+Currently supported:
+Shapes:
+	Sphere (position (x, y, z), radius, material)
+	Cylinder (position (x, y, z), radius, height, material)
+Materials:
+	Lambertian (name, color (r, g, b))
+	Transparent (name, opacity, refractiveIndex, color (r, g, b))
+Lights:
+	PointLight (position (x, y, z), color (r, g, b), intensity)

--- a/help.txt
+++ b/help.txt
@@ -3,7 +3,11 @@ Usage: raytracer <input_file>
 Currently supported:
 Shapes:
 	Sphere (position (x, y, z), radius, material)
-	Cylinder (position (x, y, z), radius, height, material)
+	Cylinder (position (x, y, z), radius, material)
+	Rectangle (position (x, y, z), width, height, material)
+	Box (position (x, y, z), width, height, depth, orientation, material)
+	LimitedCylinder (position (x, y, z), radius, height, material)
+	Plane (position (x, y, z), normal (nx, ny, nz), material)
 Materials:
 	Lambertian (name, color (r, g, b))
 	Transparent (name, opacity, refractiveIndex, color (r, g, b))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,27 +1,16 @@
 #include "core/Core.hpp"
-#include <iostream>
-
-static void help() {
-    std::cout << "Usage: raytracer <input_file>\n" << std::endl;
-    std::cout << "Currently supported:" << std::endl;
-    std::cout << "Shapes:" << std::endl;
-    std::cout << "\tSphere (position (x, y, z), radius, material)" << std::endl;
-    std::cout << "\tCylinder (position (x, y, z), radius, height, material)" << std::endl;
-    std::cout << "Materials:" << std::endl;
-    std::cout << "\tLambertian (name, color (r, g, b))" << std::endl;
-    std::cout << "\tTransparent (name, opacity, refractiveIndex, color (r, g, b))" << std::endl;
-    std::cout << "Lights:" << std::endl;
-    std::cout << "\tPointLight (position (x, y, z), color (r, g, b), intensity)" << std::endl;
-}
+#include "utils/HelpDisplay.hpp"
 
 int main(int argc, char* argv[]) {
     if (argc != 2) {
-        help();
+        HelpDisplay help;
+        help.display();
         return 84;
     }
 
     if (std::string(argv[1]) == "--help") {
-        help();
+        HelpDisplay help;
+        help.display();
         return 0;
     }
 

--- a/src/utils/HelpDisplay.cpp
+++ b/src/utils/HelpDisplay.cpp
@@ -1,0 +1,19 @@
+#include "HelpDisplay.hpp"
+#include <iostream>
+#include <fstream>
+
+HelpDisplay::HelpDisplay(const std::string& filepath) : _filepath(filepath) {}
+
+void HelpDisplay::display() const {
+    std::ifstream file(_filepath);
+
+    if (file.is_open()) {
+        std::string line;
+        while (std::getline(file, line)) {
+            std::cout << line << "\n";
+        }
+        std::cout << std::endl;
+    } else {
+        std::cout << "Usage: raytracer <input_file>" << std::endl;
+    }
+}

--- a/src/utils/HelpDisplay.hpp
+++ b/src/utils/HelpDisplay.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+class HelpDisplay {
+public:
+    explicit HelpDisplay(const std::string& filepath = "help.txt");
+    void display() const;
+
+private:
+    std::string _filepath;
+};


### PR DESCRIPTION
## What does this PR do?

This pr replace the hardcoded help flag that was on main and replace it with the help class getting data from help.txt

## Related issue

Closes #53 

## Checklist

- [ ] Code compiles without warnings
- [ ] Tests pass (`cmake --build build --target tests_run`)
- [ ] No binary/object files committed
