### PR TITLE
fix(lambertian): normalize albedo to 0-1 range to prevent color overflow

### DIFF
--- a/src/plugins/Materials/Lambertian.cpp
+++ b/src/plugins/Materials/Lambertian.cpp
@@ -1,11 +1,11 @@
 #include "Lambertian.hpp"
 #include "../../DataTypes/HitRecord.hpp"
 
-Lambertian::Lambertian(Vec3 albedo) : _albedo(albedo) {}
+Lambertian::Lambertian(Vec3 albedo) : _albedo(albedo / 255.0) {}
 
 Vec3 Lambertian::shade(const HitRecord& record, const Vec3& lightDir, [[maybe_unused]] const Vec3& lightColor) const {
     double brightness = std::max(0.0, dot(record.normal, lightDir));
-    return _albedo * brightness;
+    return _albedo * brightness * 255.0;
 }
 
 bool Lambertian::scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,


### PR DESCRIPTION
## Summary

- Albedo was stored in 0-255 range, causing accumulated multi-light contributions to exceed 255 and clamp to white
- Divides albedo by 255 in constructor, scales back to 255 in `shade()`

## Test plan

- [x] Render `scenes/basic.txt` — should look the same as before (single light, no overflow)
- [x] Render a scene with multiple lights — surfaces should no longer blow out to white

Closes #69