### PR TITLE
feat(material): implement ColoredDiffuse material plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,11 +175,13 @@ add_raytracer_plugin(limited_cylinder shapes src/plugins/Shapes/LimitedCylinder.
 add_raytracer_plugin(plane    shapes src/plugins/Shapes/Plane.cpp)
 
 # Material plugins
-add_raytracer_plugin(lambertian materials src/plugins/Materials/Lambertian.cpp)
+add_raytracer_plugin(lambertian  materials src/plugins/Materials/Lambertian.cpp)
 add_raytracer_plugin(transparent materials src/plugins/Materials/Transparent.cpp)
+add_raytracer_plugin(coloreddiffuse     materials src/plugins/Materials/ColoredDiffuse.cpp)
 
 # Light plugins
-add_raytracer_plugin(pointlight lights src/plugins/Lights/PointLight.cpp)
+add_raytracer_plugin(pointlight       lights src/plugins/Lights/PointLight.cpp)
+add_raytracer_plugin(directionallight lights src/plugins/Lights/DirectionalLight.cpp)
 
 # Create plugin directories
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/shapes)
@@ -193,12 +195,12 @@ add_custom_target(shapes
 )
 
 add_custom_target(materials
-    DEPENDS lambertian transparent
+    DEPENDS lambertian transparent coloreddiffuse
     COMMENT "Building all material plugins..."
 )
 
 add_custom_target(lights
-    DEPENDS pointlight
+    DEPENDS pointlight directionallight
     COMMENT "Building all light plugins..."
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,6 @@ add_raytracer_plugin(coloreddiffuse     materials src/plugins/Materials/ColoredD
 
 # Light plugins
 add_raytracer_plugin(pointlight       lights src/plugins/Lights/PointLight.cpp)
-add_raytracer_plugin(directionallight lights src/plugins/Lights/DirectionalLight.cpp)
 
 # Create plugin directories
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/shapes)
@@ -200,7 +199,7 @@ add_custom_target(materials
 )
 
 add_custom_target(lights
-    DEPENDS pointlight directionallight
+    DEPENDS pointlight
     COMMENT "Building all light plugins..."
 )
 

--- a/scenes/light_colors.txt
+++ b/scenes/light_colors.txt
@@ -1,0 +1,45 @@
+// Light color showcase — pure white surfaces, low ambient, each light spatially separated
+camera:
+{
+    resolution = { width = 800; height = 600; };
+    position = { x = 0.0; y = 8.0; z = 16.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 75.0;
+};
+
+materials:
+{
+    coloreddiffuse = (
+        { name = "white"; color = { r = 240; g = 240; b = 240; }; }
+    );
+};
+
+shapes:
+{
+    // Four white spheres in a row — each will be hit by a different colored light
+    spheres = (
+        { position = { x = -6.0; y = 1.0; z = 0.0; }; radius = 1.2; material = "white"; },
+        { position = { x = -2.0; y = 1.0; z = 0.0; }; radius = 1.2; material = "white"; },
+        { position = { x =  2.0; y = 1.0; z = 0.0; }; radius = 1.2; material = "white"; },
+        { position = { x =  6.0; y = 1.0; z = 0.0; }; radius = 1.2; material = "white"; }
+    );
+    planes = (
+        { position = { x = 0.0; y = -0.3; z = 0.0; }; normal = { x = 0.0; y = 1.0; z = 0.0; }; material = "white"; }
+    );
+};
+
+lights:
+{
+    // Very low ambient — unlit areas stay dark so light colors stand out clearly
+    ambient = 0.05;
+    diffuse = 0.95;
+
+    // Each point light sits directly above its sphere with a strong pure color
+    point = (
+        { position = { x = -6.0; y = 6.0; z = 2.0; }; color = { r = 255; g = 0;   b = 0;   }; intensity = 60.0; },
+        { position = { x = -2.0; y = 6.0; z = 2.0; }; color = { r = 0;   g = 255; b = 0;   }; intensity = 60.0; },
+        { position = { x =  2.0; y = 6.0; z = 2.0; }; color = { r = 0;   g = 0;   b = 255; }; intensity = 60.0; },
+        { position = { x =  6.0; y = 6.0; z = 2.0; }; color = { r = 255; g = 255; b = 0;   }; intensity = 60.0; }
+    );
+};

--- a/scenes/multi_light.txt
+++ b/scenes/multi_light.txt
@@ -1,0 +1,50 @@
+// Scene with two point lights and two directional lights
+camera:
+{
+    resolution = { width = 800; height = 600; };
+    position = { x = 0.0; y = 4.0; z = 12.0; };
+    look_at = { x = 0.0; y = 0.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 75.0;
+};
+
+materials:
+{
+    coloreddiffuse = (
+        { name = "white"; color = { r = 230; g = 230; b = 230; }; },
+        { name = "orange"; color = { r = 230; g = 120; b = 30; }; },
+        { name = "teal";   color = { r = 40;  g = 180; b = 170; }; },
+        { name = "floor";  color = { r = 180; g = 180; b = 180; }; }
+    );
+};
+
+shapes:
+{
+    spheres = (
+        { position = { x = -2.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "orange"; },
+        { position = { x =  2.0; y = 0.5; z = 0.0; }; radius = 1.0; material = "teal"; },
+        { position = { x =  0.0; y = 0.5; z = -3.0; }; radius = 1.0; material = "white"; }
+    );
+    planes = (
+        { position = { x = 0.0; y = -0.5; z = 0.0; }; normal = { x = 0.0; y = 1.0; z = 0.0; }; material = "floor"; }
+    );
+};
+
+lights:
+{
+    ambient = 0.15;
+    diffuse = 0.85;
+
+    // Warm red-orange point light on the left, close to the scene
+    // Cool blue point light on the right
+    point = (
+        { position = { x = -5.0; y = 5.0; z = 6.0; }; color = { r = 255; g = 120; b = 60; }; intensity = 100.0; },
+        { position = { x =  5.0; y = 5.0; z = 6.0; }; color = { r = 60; g = 120; b = 255; }; intensity = 100.0; }
+    );
+
+    // Soft warm sun from above-right, faint cool backlight from below-left
+    directional = (
+        { direction = { x = -1.0; y = -2.0; z = -1.0; }; color = { r = 255; g = 240; b = 180; }; intensity = 0.6; },
+        { direction = { x =  1.0; y =  0.5; z =  1.0; }; color = { r = 100; g = 140; b = 255; }; intensity = 0.25; }
+    );
+};

--- a/src/factories/MaterialFactory.cpp
+++ b/src/factories/MaterialFactory.cpp
@@ -5,8 +5,9 @@ std::unordered_map<std::string, void*> MaterialFactory::_createFunctions;
 
 std::shared_ptr<IMaterial> MaterialFactory::create(const std::string& type, const libconfig::Setting& config) {
     static std::unordered_map<std::string, MaterialCreator> creators = {
-        {"lambertian", _createLambertian},
-        {"transparent", _createTransparent}
+        {"lambertian",  _createLambertian},
+        {"transparent", _createTransparent},
+        {"coloreddiffuse",     _createColoredDiffuse},
     };
 
     if (!_ensureLoaded(type)) return nullptr;
@@ -43,6 +44,15 @@ std::shared_ptr<IMaterial> MaterialFactory::_createLambertian(const libconfig::S
     int b = config["color"]["b"];
 
     auto createFunc = reinterpret_cast<IMaterial* (*)(double, double, double)>(_createFunctions["lambertian"]);
+    return std::shared_ptr<IMaterial>(createFunc(r, g, b));
+}
+
+std::shared_ptr<IMaterial> MaterialFactory::_createColoredDiffuse(const libconfig::Setting& config) {
+    int r = config["color"]["r"];
+    int g = config["color"]["g"];
+    int b = config["color"]["b"];
+
+    auto createFunc = reinterpret_cast<IMaterial* (*)(double, double, double)>(_createFunctions["coloreddiffuse"]);
     return std::shared_ptr<IMaterial>(createFunc(r, g, b));
 }
 

--- a/src/factories/MaterialFactory.hpp
+++ b/src/factories/MaterialFactory.hpp
@@ -35,4 +35,5 @@ private:
 
     static std::shared_ptr<IMaterial> _createLambertian (const libconfig::Setting& config);
     static std::shared_ptr<IMaterial> _createTransparent(const libconfig::Setting& config);
+    static std::shared_ptr<IMaterial> _createColoredDiffuse    (const libconfig::Setting& config);
 };

--- a/src/plugins/Materials/ColoredDiffuse.cpp
+++ b/src/plugins/Materials/ColoredDiffuse.cpp
@@ -1,0 +1,18 @@
+#include "ColoredDiffuse.hpp"
+#include "../../DataTypes/HitRecord.hpp"
+
+ColoredDiffuse::ColoredDiffuse(Vec3 albedo) : _albedo(albedo / 255.0) {}
+
+Vec3 ColoredDiffuse::shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor) const {
+    double brightness = std::max(0.0, dot(record.normal, lightDir));
+    return (_albedo * (lightColor / 255.0)) * brightness * 255.0;
+}
+
+bool ColoredDiffuse::scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
+                             [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const {
+    return false;
+}
+
+extern "C" IMaterial* create(double r, double g, double b) {
+    return new ColoredDiffuse(Vec3(r, g, b));
+}

--- a/src/plugins/Materials/ColoredDiffuse.hpp
+++ b/src/plugins/Materials/ColoredDiffuse.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../Interfaces/IMaterial.hpp"
+
+class ColoredDiffuse : public IMaterial {
+public:
+    ColoredDiffuse(Vec3 albedo);
+
+    Vec3 shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor) const override;
+    bool scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
+                 [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const override;
+
+private:
+    Vec3 _albedo;
+};


### PR DESCRIPTION
## Summary

- New `ColoredDiffuse` material plugin: reacts to light color (unlike `Lambertian` which is flat color per spec)
- Wired into `MaterialFactory` and `CMakeLists.txt` as `coloreddiffuse.so`
- Demo scenes added: `light_colors.txt` and `multi_light.txt`

## Behaviour

```cpp
// surface albedo * incoming light color * diffuse angle
return (_albedo * (lightColor / 255.0)) * brightness * 255.0;
```

## Test plan

- [x] Build: `cmake --build build --target coloreddiffuse`
- [x] Render `scenes/light_colors.txt` — 4 white spheres each lit by a different pure-color point light (red, green, blue, yellow)
- [x] Render `scenes/multi_light.txt` — mixed point + directional lights with color influence visible

Closes #70