### PR TITLE
feat(light): implement DirectionalLight plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,8 @@ add_raytracer_plugin(lambertian materials src/plugins/Materials/Lambertian.cpp)
 add_raytracer_plugin(transparent materials src/plugins/Materials/Transparent.cpp)
 
 # Light plugins
-add_raytracer_plugin(pointlight lights src/plugins/Lights/PointLight.cpp)
+add_raytracer_plugin(pointlight       lights src/plugins/Lights/PointLight.cpp)
+add_raytracer_plugin(directionallight lights src/plugins/Lights/DirectionalLight.cpp)
 
 # Create plugin directories
 file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/shapes)
@@ -191,7 +192,7 @@ add_custom_target(materials
 )
 
 add_custom_target(lights
-    DEPENDS pointlight
+    DEPENDS pointlight directionallight
     COMMENT "Building all light plugins..."
 )
 

--- a/src/factories/LightFactory.cpp
+++ b/src/factories/LightFactory.cpp
@@ -6,6 +6,7 @@ std::unordered_map<std::string, void*> LightFactory::_createFunctions;
 std::shared_ptr<ILight> LightFactory::create(const std::string& type, const libconfig::Setting& config) {
     static std::unordered_map<std::string, LightCreator> creators = {
         {"point", _createPointLight},
+        {"directional", _createDirectionalLight},
     };
 
     if (!_ensureLoaded(type)) return nullptr;
@@ -43,4 +44,19 @@ std::shared_ptr<ILight> LightFactory::_createPointLight(const libconfig::Setting
 
     auto createFunc = reinterpret_cast<ILight* (*)(double, double, double, double, double, double, double)>(_createFunctions["point"]);
     return std::shared_ptr<ILight>(createFunc(px, py, pz, cr, cg, cb, intensity));
+}
+
+std::shared_ptr<ILight> LightFactory::_createDirectionalLight(const libconfig::Setting& config) {
+    double nx = config["direction"]["x"];
+    double ny = config["direction"]["y"];
+    double nz = config["direction"]["z"];
+
+    int cr = config["color"]["r"];
+    int cg = config["color"]["g"];
+    int cb = config["color"]["b"];
+
+    double intensity = config["intensity"];
+
+    auto createFunc = reinterpret_cast<ILight* (*)(double, double, double, double, double, double, double)>(_createFunctions["directional"]);
+    return std::shared_ptr<ILight>(createFunc(nx, ny, nz, cr, cg, cb, intensity));
 }

--- a/src/factories/LightFactory.hpp
+++ b/src/factories/LightFactory.hpp
@@ -34,4 +34,5 @@ private:
     static bool _ensureLoaded(const std::string& type);
 
     static std::shared_ptr<ILight> _createPointLight(const libconfig::Setting& config);
+    static std::shared_ptr<ILight> _createDirectionalLight(const libconfig::Setting& config);
 };

--- a/src/plugins/Lights/DirectionalLight.cpp
+++ b/src/plugins/Lights/DirectionalLight.cpp
@@ -1,0 +1,16 @@
+#include "DirectionalLight.hpp"
+
+DirectionalLight::DirectionalLight(Vec3 direction, Vec3 color, double intensity)
+    : _direction(direction), _color(color), _intensity(intensity) {}
+
+double DirectionalLight::get_light_data([[maybe_unused]] const Vec3& hit_point, Vec3& direction,
+                                        Vec3& color) const {
+    direction = normalize(-_direction);
+    color = _color * _intensity;
+    return 1e9;
+}
+
+extern "C" ILight* create(double nx, double ny, double nz, double r, double g, double b,
+                          double intensity) {
+    return new DirectionalLight(Vec3(nx, ny, nz), Vec3(r, g, b), intensity);
+}

--- a/src/plugins/Lights/DirectionalLight.hpp
+++ b/src/plugins/Lights/DirectionalLight.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../Interfaces/ILight.hpp"
+
+class DirectionalLight : public ILight {
+public:
+    DirectionalLight(Vec3 direction, Vec3 color, double intensity);
+
+    double get_light_data(const Vec3& hit_point, Vec3& direction, Vec3& color) const override;
+
+private:
+    Vec3 _direction;
+    Vec3 _color;
+    double _intensity;
+};


### PR DESCRIPTION
## Summary

- Implements `DirectionalLight` class — infinite distance light with no falloff, defined by direction and color
- Wired into `LightFactory` and `CMakeLists.txt` as `directionallight.so`

## Behaviour

Unlike point lights, directional lights have no position and no distance attenuation. The direction is fixed — think sunlight.

## Test plan

- [x] Build: `cmake --build build --target directionallight`
- [x] Use `directional = (...)` in a scene config and verify consistent lighting from the given direction

Closes #25