### PR TITLE
Refactor/imaterial add viewdir to shade

### DIFF
--- a/src/Interfaces/IMaterial.hpp
+++ b/src/Interfaces/IMaterial.hpp
@@ -21,7 +21,7 @@ public:
      * @param lightColor The color and intensity of the light source.
      * @return The Vec3 color contribution (how much this light brightens the pixel).
      */
-    virtual Vec3 shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor) const = 0;
+    virtual Vec3 shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor, const Vec3& viewDir) const = 0;
 
     /**
      * @brief [Indirect Lighting] Determines if and how light bounces off the surface.

--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -1,7 +1,9 @@
 #include "Core.hpp"
+
+#include <iostream>
+
 #include "../parsers/SceneParser.hpp"
 #include "Image.hpp"
-#include <iostream>
 
 bool Core::simulate() {
     try {
@@ -44,8 +46,10 @@ Vec3 Core::trace(const Ray& ray, const Scene& scene, int depth) {
             Ray shadowRay(record.point, lightDir);
             HitRecord shadowRecord;
 
+            Vec3 viewDir = -ray.direction();
             if (!scene.world().get_closest_hit(shadowRay, _t_min, lightDistance, shadowRecord)) {
-                color += record.material->shade(record, lightDir, lightColor) * scene.diffuseMultiplier();
+                color += record.material->shade(record, lightDir, lightColor, viewDir) *
+                         scene.diffuseMultiplier();
             }
         }
 

--- a/src/plugins/Materials/ColoredDiffuse.cpp
+++ b/src/plugins/Materials/ColoredDiffuse.cpp
@@ -1,15 +1,19 @@
 #include "ColoredDiffuse.hpp"
+
 #include "../../DataTypes/HitRecord.hpp"
 
 ColoredDiffuse::ColoredDiffuse(Vec3 albedo) : _albedo(albedo / 255.0) {}
 
-Vec3 ColoredDiffuse::shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor) const {
+Vec3 ColoredDiffuse::shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor,
+                           [[maybe_unused]] const Vec3& viewDir) const {
     double brightness = std::max(0.0, dot(record.normal, lightDir));
     return (_albedo * (lightColor / 255.0)) * brightness * 255.0;
 }
 
-bool ColoredDiffuse::scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
-                             [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const {
+bool ColoredDiffuse::scatter([[maybe_unused]] const Ray& ray_in,
+                             [[maybe_unused]] const HitRecord& record,
+                             [[maybe_unused]] Vec3& attenuation,
+                             [[maybe_unused]] Ray& scattered) const {
     return false;
 }
 

--- a/src/plugins/Materials/ColoredDiffuse.hpp
+++ b/src/plugins/Materials/ColoredDiffuse.hpp
@@ -6,9 +6,11 @@ class ColoredDiffuse : public IMaterial {
 public:
     ColoredDiffuse(Vec3 albedo);
 
-    Vec3 shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor) const override;
+    Vec3 shade(const HitRecord& record, const Vec3& lightDir, const Vec3& lightColor,
+               [[maybe_unused]] const Vec3& viewDir) const override;
     bool scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
-                 [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const override;
+                 [[maybe_unused]] Vec3& attenuation,
+                 [[maybe_unused]] Ray& scattered) const override;
 
 private:
     Vec3 _albedo;

--- a/src/plugins/Materials/Lambertian.cpp
+++ b/src/plugins/Materials/Lambertian.cpp
@@ -1,18 +1,21 @@
 #include "Lambertian.hpp"
+
 #include "../../DataTypes/HitRecord.hpp"
 
 Lambertian::Lambertian(Vec3 albedo) : _albedo(albedo / 255.0) {}
 
-Vec3 Lambertian::shade(const HitRecord& record, const Vec3& lightDir, [[maybe_unused]] const Vec3& lightColor) const {
+Vec3 Lambertian::shade(const HitRecord& record, const Vec3& lightDir,
+                       [[maybe_unused]] const Vec3& lightColor,
+                       [[maybe_unused]] const Vec3& viewDir) const {
     double brightness = std::max(0.0, dot(record.normal, lightDir));
     return _albedo * brightness * 255.0;
 }
 
-bool Lambertian::scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
-                         [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const {
+bool Lambertian::scatter([[maybe_unused]] const Ray& ray_in,
+                         [[maybe_unused]] const HitRecord& record,
+                         [[maybe_unused]] Vec3& attenuation,
+                         [[maybe_unused]] Ray& scattered) const {
     return false;
 }
 
-extern "C" IMaterial* create(double r, double g, double b) {
-    return new Lambertian(Vec3(r, g, b));
-}
+extern "C" IMaterial* create(double r, double g, double b) { return new Lambertian(Vec3(r, g, b)); }

--- a/src/plugins/Materials/Lambertian.hpp
+++ b/src/plugins/Materials/Lambertian.hpp
@@ -6,7 +6,8 @@ class Lambertian : public IMaterial {
 public:
     Lambertian(Vec3 albedo);
 
-    Vec3 shade(const HitRecord& record, const Vec3& lightDir, [[maybe_unused]] const Vec3& lightColor) const override;
+    Vec3 shade(const HitRecord& record, const Vec3& lightDir, [[maybe_unused]] const Vec3& lightColor,
+               const Vec3& viewDir) const override;
     bool scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,
                  [[maybe_unused]] Vec3& attenuation, [[maybe_unused]] Ray& scattered) const override;
 

--- a/src/plugins/Materials/Transparent.cpp
+++ b/src/plugins/Materials/Transparent.cpp
@@ -1,17 +1,22 @@
 #include "Transparent.hpp"
-#include "../../DataTypes/HitRecord.hpp"
+
 #include <cmath>
+
+#include "../../DataTypes/HitRecord.hpp"
 
 Transparent::Transparent(double opacity, double refractiveIndex, Vec3 color)
     : _opacity(opacity), _refractiveIndex(refractiveIndex), _color(color) {}
 
-Vec3 Transparent::shade([[maybe_unused]] const HitRecord& record, [[maybe_unused]] const Vec3& lightDir,
-                        [[maybe_unused]] const Vec3& lightColor) const {
+Vec3 Transparent::shade([[maybe_unused]] const HitRecord& record,
+                        [[maybe_unused]] const Vec3& lightDir,
+                        [[maybe_unused]] const Vec3& lightColor,
+                        [[maybe_unused]] const Vec3& viewDir) const {
     // Transparent materials don't contribute much to direct lighting
     return Vec3(0, 0, 0);
 }
 
-bool Transparent::scatter(const Ray& ray_in, const HitRecord& record, Vec3& attenuation, Ray& scattered) const {
+bool Transparent::scatter(const Ray& ray_in, const HitRecord& record, Vec3& attenuation,
+                          Ray& scattered) const {
     attenuation = _color / 255.0;
 
     double refractionRatio = record.front_face ? (1.0 / _refractiveIndex) : _refractiveIndex;
@@ -39,9 +44,7 @@ bool Transparent::scatter(const Ray& ray_in, const HitRecord& record, Vec3& atte
 }
 
 // Helper function: reflection
-Vec3 Transparent::reflect(const Vec3& v, const Vec3& n) const {
-    return v - 2.0 * dot(v, n) * n;
-}
+Vec3 Transparent::reflect(const Vec3& v, const Vec3& n) const { return v - 2.0 * dot(v, n) * n; }
 
 // Helper function: refraction (Snell's Law in vector form)
 Vec3 Transparent::refract(const Vec3& uv, const Vec3& n, double etai_over_etat) const {

--- a/src/plugins/Materials/Transparent.hpp
+++ b/src/plugins/Materials/Transparent.hpp
@@ -7,7 +7,7 @@ public:
     Transparent(double opacity, double refractiveIndex, Vec3 color);
 
     Vec3 shade([[maybe_unused]] const HitRecord& record, [[maybe_unused]] const Vec3& lightDir,
-               [[maybe_unused]] const Vec3& lightColor) const override;
+               [[maybe_unused]] const Vec3& lightColor,  [[maybe_unused]] const Vec3& viewDir) const override;
     bool scatter(const Ray& ray_in, const HitRecord& record, Vec3& attenuation, Ray& scattered) const override;
 
 private:


### PR DESCRIPTION
## What does this PR do?

Changed the IMaterial interface. The shade method now knows the position where the camera is looking from. This is mandatory for Phong diffusion method. 

adapted everything that used this API to now match the new version.

## Related issue

Closes #77 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
