### PR TITLE
Fix/add uv coordinates to hitrecord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ run_tests
 
 # test results
 tests/results/
+
+.vscode/

--- a/src/DataTypes/HitRecord.hpp
+++ b/src/DataTypes/HitRecord.hpp
@@ -15,6 +15,8 @@ public:
     double t;
     bool front_face;
     std::shared_ptr<IMaterial> material;
+    double u = 0.0;
+    double v = 0.0;
 
     void set_face_normal(const Ray& r, const Vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;


### PR DESCRIPTION
## What does this PR do?

added fields u & v to hitrecord for texture mapping

## Related issue

Closes #99 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
