### PR TITLE
Fix/add uv coord to shapes

### DIFF
--- a/scenes/chessboard.txt
+++ b/scenes/chessboard.txt
@@ -1,7 +1,7 @@
 camera:
 {
     resolution = { width = 800; height = 600; };
-    position = { x = 0.0; y = 10.0; z = 20.0; };
+    position = { x = 0.0; y = 10.0; z = 10.0; };
     look_at = { x = 0.0; y = 0.0; z = 0.0; };
     up = { x = 0.0; y = 1.0; z = 0.0; };
     fieldOfView = 75.0;
@@ -13,17 +13,17 @@ materials:
         { name = "red_sphere"; color = { r = 200; g = 60; b = 60; }; shininess = 32.0; }
     );
     chessboard = (
-        { name = "floor"; color1 = { r = 255; g = 255; b = 255; }; color2 = { r = 20; g = 20; b = 20; }; scale = 0.6; }
+        { name = "floor"; color1 = { r = 255; g = 255; b = 255; }; color2 = { r = 20; g = 20; b = 20; }; scale = 6.0 }
     );
 };
 
 shapes:
 {
     planes = (
-        { position = { x = 0.0; y = 0.0; z = 0.0; }; normal = { x = 0.0; y = 1.0; z = 0.0; }; material = "floor"; }
+        { position = { x = 0.0; y = 0.0; z = 0.0; }; normal = { x = 0.0; y = 1.0; z = 0.0; }; material = "red_sphere"; }
     );
     spheres = (
-        { position = { x = 0.0; y = 2.0; z = 0.0; }; radius = 2.0; material = "red_sphere"; }
+        { position = { x = 0.0; y = 2.0; z = 0.0; }; radius = 2.0; material = "floor"; }
     );
 };
 

--- a/scenes/showcase_chessboard.txt
+++ b/scenes/showcase_chessboard.txt
@@ -1,0 +1,95 @@
+camera:
+{
+    resolution = { width = 1000; height = 1000; };
+    position = { x = 12.0; y = 8.0; z = 15.0; };
+    look_at = { x = 0.0; y = 2.0; z = 0.0; };
+    up = { x = 0.0; y = 1.0; z = 0.0; };
+    fieldOfView = 70.0;
+};
+
+materials:
+{
+    chessboard = (
+        { name = "cb_bw";     color1 = { r = 255; g = 255; b = 255; }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_red";    color1 = { r = 220; g = 60;  b = 60;  }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_green";  color1 = { r = 60;  g = 220; b = 60;  }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_blue";   color1 = { r = 60;  g = 120; b = 220; }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_yellow"; color1 = { r = 230; g = 200; b = 50;  }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_purple"; color1 = { r = 180; g = 60;  b = 200; }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_cyan";   color1 = { r = 60;  g = 200; b = 200; }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_orange"; color1 = { r = 240; g = 140; b = 40;  }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_pink";   color1 = { r = 255; g = 100; b = 150; }; color2 = { r = 20;  g = 20;  b = 20;  }; scale = 6.0; },
+        { name = "cb_floor";  color1 = { r = 200; g = 200; b = 200; }; color2 = { r = 60;  g = 60;  b = 60;  }; scale = 4.0; }
+    );
+
+    coloreddiffuse = (
+        { name = "floor"; color = { r = 180; g = 180; b = 180; }; }
+    );
+};
+
+shapes:
+{
+    planes = (
+        { position = { x = 0.0; y = 0.0; z = 0.0; }; normal = { x = 0.0; y = 1.0; z = 0.0; }; material = "floor"; }
+    );
+
+    spheres = (
+        { position = { x = -6.0; y = 1.0; z = -2.0; }; radius = 1.0; material = "cb_red"; rotation = { x = 0.0; y = 0.0; z = 0.0; }; }
+    );
+
+    limited_cylinders = (
+        { position = { x = -4.0; y = 1.5; z = 1.0; }; radius = 0.6; height = 3.0; material = "cb_green"; rotation = { x = 0.0; y = 20.0; z = 0.0; }; }
+    );
+
+    limited_cones = (
+        { position = { x = -2.0; y = 2.5; z = -1.5; }; radius = 0.7; height = 2.5; material = "cb_blue"; rotation = { x = 0.0; y = -30.0; z = 0.0; }; }
+    );
+
+    limited_hourglasses = (
+        { position = { x = 0.0; y = 2.0; z = 2.0; }; radius = 0.6; height = 2.0; material = "cb_yellow"; rotation = { x = 0.0; y = 45.0; z = 0.0; }; }
+    );
+
+    rectangles = (
+        { position = { x = 2.0; y = 2.0; z = -2.0; }; width = 2.0; height = 3.0; material = "cb_purple"; rotation = { x = 0.0; y = 60.0; z = 0.0; }; }
+    );
+
+    boxes = (
+        { position = { x = 4.0; y = 1.2; z = 1.5; }; width = 1.8; height = 2.4; depth = 1.2; material = "cb_cyan"; rotation = { x = 0.0; y = -45.0; z = 15.0; }; }
+    );
+
+    toruses = (
+        { position = { x = 6.0; y = 2.5; z = -1.0; }; major_radius = 1.2; minor_radius = 0.4; material = "cb_orange"; rotation = { x = 45.0; y = 30.0; z = 0.0; }; }
+    );
+
+    tanglecubes = (
+        { position = { x = -6.0; y = 1.5; z = 4.0; }; scale = 0.4; material = "cb_pink"; rotation = { x = 20.0; y = -40.0; z = 10.0; }; }
+    );
+
+    cylinders = (
+        { position = { x = 8.0; y = 0.0; z = 0.0; }; radius = 0.3; material = "cb_red"; axis = { x = 0.3; y = 1.0; z = 0.2; }; }
+    );
+
+    cones = (
+        { position = { x = -8.0; y = 3.0; z = 0.0; }; radius = 0.4; material = "cb_green"; axis = { x = -0.4; y = 1.0; z = 0.1; }; }
+    );
+
+    hourglasses = (
+        { position = { x = 0.0; y = 0.0; z = -5.0; }; radius = 0.35; material = "cb_blue"; axis = { x = 0.2; y = 1.0; z = -0.3; }; }
+    );
+};
+
+lights:
+{
+    ambient = 0.15;
+    diffuse = 0.85;
+
+    point = (
+        { position = { x = 8.0; y = 12.0; z = 8.0; }; color = { r = 255; g = 240; b = 220; }; intensity = 80.0; },
+        { position = { x = -6.0; y = 8.0; z = 6.0; }; color = { r = 180; g = 200; b = 255; }; intensity = 50.0; },
+        { position = { x = 0.0; y = 5.0; z = -8.0; }; color = { r = 255; g = 180; b = 200; }; intensity = 40.0; }
+    );
+
+    directional = (
+        { direction = { x = 0.5; y = -1.0; z = 0.3; }; color = { r = 255; g = 230; b = 200; }; intensity = 0.7; }
+    );
+};

--- a/src/Math/Constants.hpp
+++ b/src/Math/Constants.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Math {
+    constexpr double PI = 3.14159265358979323846;
+    constexpr double TWO_PI = 2.0 * PI;
+    constexpr double INV_PI = 1.0 / PI;
+    constexpr double INV_TWO_PI = 1.0 / TWO_PI;
+}

--- a/src/core/AShape.cpp
+++ b/src/core/AShape.cpp
@@ -71,6 +71,8 @@ HitRecord AShape::localToWorld(const HitRecord& local, const Ray& worldRay) cons
     world.point = worldPoint;
     world.t = local.t;
     world.material = local.material;
+    world.u = local.u;
+    world.v = local.v;
     world.set_face_normal(worldRay, worldNormal);
 
     return world;

--- a/src/plugins/Materials/Chessboard.cpp
+++ b/src/plugins/Materials/Chessboard.cpp
@@ -7,15 +7,11 @@ Chessboard::Chessboard(Vec3 color1, Vec3 color2, double scale)
 
 Vec3 Chessboard::shade(const HitRecord& record, const Vec3& lightDir, [[maybe_unused]] const Vec3& lightColor, [[maybe_unused]] const Vec3& viewDir) const {
 
-    // TODO: switch to UV coordinates (record.u, record.v) once #87 lands
-    // Bias avoids floor() flipping sign on near-zero coordinates (floating point hit point noise)
-    constexpr double eps = 1e-5;
-    int check = static_cast<int>(std::floor(record.point.x() * _scale + eps)) +
-                static_cast<int>(std::floor(record.point.y() * _scale + eps)) +
-                static_cast<int>(std::floor(record.point.z() * _scale + eps));
+    int check = static_cast<int>(std::floor(record.u * _scale)) +
+                static_cast<int>(std::floor(record.v * _scale));
     Vec3 baseColor = (check % 2 == 0) ? _color1 : _color2;
     double brightness = std::max(0.0, dot(record.normal, lightDir));
-    return baseColor * brightness * 255.0;
+    return baseColor * (lightColor / 255.0) * brightness * 255.0;
 }
 
 bool Chessboard::scatter([[maybe_unused]] const Ray& ray_in, [[maybe_unused]] const HitRecord& record,

--- a/src/plugins/Shapes/Box.cpp
+++ b/src/plugins/Shapes/Box.cpp
@@ -1,4 +1,5 @@
 #include "Box.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
 
 Box::Box(Vec3 rotation, Vec3 translation, double width, double height, double depth, std::shared_ptr<IMaterial> material)
@@ -66,6 +67,18 @@ bool Box::hitLocal(const Ray& ray, HitRecord& record) const {
     record.point = ray.at(t_min);
     record.material = _material;
     record.set_face_normal(ray, normal);
+
+    Vec3 hit = record.point;
+    if (hit_axis == 0) {
+        record.u = (hit.z() + _depth / 2.0) / _depth;
+        record.v = (hit.y() + _height / 2.0) / _height;
+    } else if (hit_axis == 1) {
+        record.u = (hit.x() + _width / 2.0) / _width;
+        record.v = (hit.z() + _depth / 2.0) / _depth;
+    } else {
+        record.u = (hit.x() + _width / 2.0) / _width;
+        record.v = (hit.y() + _height / 2.0) / _height;
+    }
 
     return true;
 }

--- a/src/plugins/Shapes/Cone.cpp
+++ b/src/plugins/Shapes/Cone.cpp
@@ -1,6 +1,7 @@
 #include "./Cone.hpp"
 #include "DataTypes/Vec3.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
 
 static constexpr double EPS = 1e-9;
@@ -53,6 +54,15 @@ bool Cone::hit(const Ray& ray, double t_min, double t_max, HitRecord& record) co
         record.point = hitpoint;
         record.material = _material;
         record.set_face_normal(ray, outward_norm);
+
+        double perp_len = length(p_perp);
+        if (perp_len > 1e-9) {
+            Vec3 ref = (std::abs(_axis.x()) < 0.9) ? Vec3(1, 0, 0) : Vec3(0, 1, 0);
+            Vec3 tangent = normalize(cross(ref, _axis));
+            Vec3 pn = p_perp / perp_len;
+            record.u = std::atan2(dot(pn, cross(_axis, tangent)), dot(pn, tangent)) * Math::INV_TWO_PI + 0.5;
+        }
+        record.v = -along_axis;
 
         return true;
     }

--- a/src/plugins/Shapes/Cylinder.cpp
+++ b/src/plugins/Shapes/Cylinder.cpp
@@ -1,5 +1,7 @@
 #include "Cylinder.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
+#include <cmath>
 
 Cylinder::Cylinder(Vec3 pos, Vec3 axis, double radius, std::shared_ptr<IMaterial> material)
     : _position(pos), _axis(normalize(axis)), _radius(radius), _material(material) {}
@@ -23,6 +25,9 @@ bool Cylinder::checkBodyIntersection(const Ray& ray, double t_min, double& close
     QuadraticRoots roots = QuadraticSolver::solve(a, b, c);
     if (!roots.hasRoots()) return false;
 
+    Vec3 ref = (std::abs(_axis.x()) < 0.9) ? Vec3(1, 0, 0) : Vec3(0, 1, 0);
+    Vec3 tangent = normalize(cross(ref, _axis));
+
     bool found_hit = false;
     for (double t : {roots.t1, roots.t2}) {
         if (t > t_min && t < closest_t) {
@@ -32,6 +37,15 @@ bool Cylinder::checkBodyIntersection(const Ray& ray, double t_min, double& close
             record.point = hit_point;
             record.set_face_normal(ray, computeBodyNormal(hit_point));
             record.material = _material;
+
+            Vec3 p = hit_point - _position;
+            Vec3 p_perp = p - _axis * dot(p, _axis);
+            double perp_len = length(p_perp);
+            if (perp_len > 1e-9) {
+                Vec3 pn = p_perp / perp_len;
+                record.u = std::atan2(dot(pn, cross(_axis, tangent)), dot(pn, tangent)) * Math::INV_TWO_PI + 0.5;
+            }
+            record.v = dot(p, _axis);
 
             closest_t = t;
             found_hit = true;

--- a/src/plugins/Shapes/Hourglass.cpp
+++ b/src/plugins/Shapes/Hourglass.cpp
@@ -1,6 +1,7 @@
 #include "./Hourglass.hpp"
 #include "DataTypes/Vec3.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
 
 Hourglass::Hourglass(Vec3 pos, Vec3 axis, double radius, std::shared_ptr<IMaterial> material)
@@ -47,6 +48,15 @@ bool Hourglass::hit(const Ray& ray, double t_min, double t_max, HitRecord& recor
         record.point = hitpoint;
         record.material = _material;
         record.set_face_normal(ray, outward_norm);
+
+        double perp_len = length(p_perp);
+        if (perp_len > 1e-9) {
+            Vec3 ref = (std::abs(_axis.x()) < 0.9) ? Vec3(1, 0, 0) : Vec3(0, 1, 0);
+            Vec3 tangent = normalize(cross(ref, _axis));
+            Vec3 pn = p_perp / perp_len;
+            record.u = std::atan2(dot(pn, cross(_axis, tangent)), dot(pn, tangent)) * Math::INV_TWO_PI + 0.5;
+        }
+        record.v = along_axis;
 
         return true;
     }

--- a/src/plugins/Shapes/LimitedCone.cpp
+++ b/src/plugins/Shapes/LimitedCone.cpp
@@ -1,5 +1,6 @@
 #include "LimitedCone.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
 #include <limits>
 
@@ -48,6 +49,8 @@ bool LimitedCone::hitLocal(const Ray& ray, HitRecord& record) const {
                 record.point = hitpoint;
                 record.material = _material;
                 record.set_face_normal(ray, outward_norm);
+                record.u = std::atan2(hitpoint.z(), hitpoint.x()) * Math::INV_TWO_PI + 0.5;
+                record.v = -hitpoint.y() / _height;
 
                 closest_t = t;
                 hit_anything = true;
@@ -84,6 +87,8 @@ bool LimitedCone::checkBaseIntersection(const Ray& ray, double& closest_t, HitRe
     record.point = hit_point;
     record.material = _material;
     record.set_face_normal(ray, Vec3(0, -1, 0));
+    record.u = hit_point.x() / (2.0 * base_radius) + 0.5;
+    record.v = hit_point.z() / (2.0 * base_radius) + 0.5;
 
     return true;
 }

--- a/src/plugins/Shapes/LimitedCylinder.cpp
+++ b/src/plugins/Shapes/LimitedCylinder.cpp
@@ -1,5 +1,7 @@
 #include "LimitedCylinder.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
+#include <cmath>
 #include <limits>
 
 LimitedCylinder::LimitedCylinder(Vec3 rotation, Vec3 translation, double radius, double height, std::shared_ptr<IMaterial> material)
@@ -43,6 +45,8 @@ bool LimitedCylinder::checkBodyIntersection(const Ray& ray, double t_min, double
                 record.point = hit_point;
                 record.set_face_normal(ray, computeBodyNormal(hit_point));
                 record.material = _material;
+                record.u = std::atan2(hit_point.z(), hit_point.x()) * Math::INV_TWO_PI + 0.5;
+                record.v = y / _height;
 
                 closest_t = t;
                 found_hit = true;
@@ -75,6 +79,8 @@ bool LimitedCylinder::checkCapIntersection(const Ray& ray, double cap_y, const V
     record.point = hit_point;
     record.set_face_normal(ray, normal);
     record.material = _material;
+    record.u = hit_point.x() / (2.0 * _radius) + 0.5;
+    record.v = hit_point.z() / (2.0 * _radius) + 0.5;
 
     closest_t = t;
     return true;

--- a/src/plugins/Shapes/LimitedHourglass.cpp
+++ b/src/plugins/Shapes/LimitedHourglass.cpp
@@ -1,5 +1,6 @@
 #include "LimitedHourglass.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
 #include <limits>
 
@@ -47,6 +48,8 @@ bool LimitedHourglass::hitLocal(const Ray& ray, HitRecord& record) const {
                 record.point = hitpoint;
                 record.material = _material;
                 record.set_face_normal(ray, outward_norm);
+                record.u = std::atan2(hitpoint.z(), hitpoint.x()) * Math::INV_TWO_PI + 0.5;
+                record.v = (hitpoint.y() + _height / 2.0) / _height;
 
                 closest_t = t;
                 hit_anything = true;
@@ -86,6 +89,13 @@ bool LimitedHourglass::checkCapIntersection(const Ray& ray, double cap_y, double
     record.point = hit_point;
     record.material = _material;
     record.set_face_normal(ray, normal);
+    if (cap_radius > 1e-9) {
+        record.u = hit_point.x() / (2.0 * cap_radius) + 0.5;
+        record.v = hit_point.z() / (2.0 * cap_radius) + 0.5;
+    } else {
+        record.u = 0.5;
+        record.v = 0.5;
+    }
 
     closest_t = t;
     return true;

--- a/src/plugins/Shapes/Plane.cpp
+++ b/src/plugins/Shapes/Plane.cpp
@@ -1,4 +1,6 @@
 #include "Plane.hpp"
+#include "../../Math/Constants.hpp"
+#include <cmath>
 
 Plane::Plane(Vec3 pos, Vec3 normal, std::shared_ptr<IMaterial> material)
     : _pos(pos), _normal(normal), _material(material) {}
@@ -15,6 +17,14 @@ bool Plane::hit(const Ray& ray, double t_min, double t_max, HitRecord& record) c
     record.point = ray.at(t);
     record.material = _material;
     record.set_face_normal(ray, _normal);
+
+    Vec3 up_hint = (std::abs(_normal.y()) < 0.9) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+    Vec3 tangent = normalize(cross(up_hint, _normal));
+    Vec3 bitangent = cross(_normal, tangent);
+    Vec3 local = record.point - _pos;
+    record.u = dot(local, tangent);
+    record.v = dot(local, bitangent);
+
     return true;
 }
 

--- a/src/plugins/Shapes/Rectangle.cpp
+++ b/src/plugins/Shapes/Rectangle.cpp
@@ -28,6 +28,8 @@ bool Rectangle::hitLocal(const Ray& ray, HitRecord& record) const {
     record.t = t;
     record.material = _material;
     record.set_face_normal(ray, Vec3(0, 0, 1));
+    record.u = (hit_point.x() + _width / 2.0) / _width;
+    record.v = (hit_point.y() + _height / 2.0) / _height;
 
     return true;
 }

--- a/src/plugins/Shapes/Sphere.cpp
+++ b/src/plugins/Shapes/Sphere.cpp
@@ -1,5 +1,8 @@
 #include "Sphere.hpp"
 #include "../../Math/QuadraticSolver.hpp"
+#include "../../Math/Constants.hpp"
+#include <cmath>
+#include <algorithm>
 
 Sphere::Sphere(Vec3 rotation, Vec3 translation, double radius, std::shared_ptr<IMaterial> material)
     : AShape(rotation, translation), _radius(radius), _material(material) {}
@@ -30,6 +33,11 @@ bool Sphere::hitLocal(const Ray& ray, HitRecord& record) const {
     record.t = t;
     record.material = _material;
     record.set_face_normal(ray, outward_normal);
+
+    double phi = std::atan2(-outward_normal.z(), outward_normal.x()) + Math::PI;
+    double cos_theta = std::clamp(-outward_normal.y(), -1.0, 1.0);
+    record.u = phi * Math::INV_TWO_PI;
+    record.v = std::acos(cos_theta) * Math::INV_PI;
 
     return true;
 }

--- a/src/plugins/Shapes/Tanglecube.cpp
+++ b/src/plugins/Shapes/Tanglecube.cpp
@@ -1,6 +1,8 @@
 #include "Tanglecube.hpp"
 #include "../../Math/QuarticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <cmath>
+#include <algorithm>
 
 Tanglecube::Tanglecube(Vec3 rotation, Vec3 translation, double scale, std::shared_ptr<IMaterial> material)
     : AShape(rotation, translation), _scale(scale), _material(material) {}
@@ -93,6 +95,12 @@ bool Tanglecube::hitLocal(const Ray& ray, HitRecord& record) const {
         outward_normal = normalize(outward_normal);
         record.normal = outward_normal;
         record.front_face = true;
+
+        Vec3 d = normalize(record.point);
+        double phi = std::atan2(-d.z(), d.x()) + Math::PI;
+        double cos_theta = std::clamp(-d.y(), -1.0, 1.0);
+        record.u = phi * Math::INV_TWO_PI;
+        record.v = std::acos(cos_theta) * Math::INV_PI;
 
         return true;
     }

--- a/src/plugins/Shapes/Torus.cpp
+++ b/src/plugins/Shapes/Torus.cpp
@@ -1,5 +1,6 @@
 #include "Torus.hpp"
 #include "../../Math/QuarticSolver.hpp"
+#include "../../Math/Constants.hpp"
 #include <algorithm>
 #include <cmath>
 
@@ -46,6 +47,13 @@ bool Torus::hitLocal(const Ray& ray, HitRecord& record) const {
     Vec3 outward_normal = computeNormal(record.point);
     record.normal = outward_normal;
     record.front_face = true;
+
+    Vec3 p = record.point;
+    double phi = std::atan2(p.z(), p.x());
+    double theta = std::atan2(p.y(), std::sqrt(p.x() * p.x() + p.z() * p.z()) - _majorRadius);
+    record.u = phi * Math::INV_TWO_PI + 0.5;
+    record.v = theta * Math::INV_TWO_PI + 0.5;
+
     return true;
 }
 


### PR DESCRIPTION
## What does this PR do?

every shape now correctly fills out UV coords in their HitRecord. this allows proper texture rendering (chessboard material or assets, in the future)

## Related issue

Closes #105 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
