### PR TITLE
feat(bvh): implement BVHNode with longest-axis split and AABB traversal

### DIFF
--- a/src/Interfaces/IShape.hpp
+++ b/src/Interfaces/IShape.hpp
@@ -2,6 +2,7 @@
 
 #include "../DataTypes/Ray.hpp"
 #include "../DataTypes/HitRecord.hpp"
+#include "../Math/AABB.hpp"
 
 /**
  * @brief Interface for shapes that can be hit by rays.
@@ -21,4 +22,11 @@ public:
      * @return True if a hit is found, false otherwise.
      */
     virtual bool hit(const Ray& ray, double t_min, double t_max, HitRecord& record) const = 0;
+    /**
+     * @brief Returns the axis-aligned bounding box of this shape.
+     * @note Infinite shapes (plane, cylinder...) don't have a meaningful AABB,
+     *       so the default returns an empty box. Only shapes used inside a BVH
+     *       (e.g. Triangle) need to override this.
+     */
+    virtual AABB boundingBox() const { return AABB{}; }
 };

--- a/src/Math/BVHNode.hpp
+++ b/src/Math/BVHNode.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "AABB.hpp"
+#include "../Interfaces/IShape.hpp"
+#include "../plugins/Shapes/Triangle.hpp"
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+class BVHNode : public IShape {
+public:
+    BVHNode(std::vector<std::shared_ptr<Triangle>>& triangles, size_t start, size_t end) {
+        size_t count = end - start;
+
+        if (count == 1) {
+            _left = _right = triangles[start];
+        } else if (count == 2) {
+            _left  = triangles[start];
+            _right = triangles[start + 1];
+        } else {
+            AABB centroidBox = triangles[start]->boundingBox();
+            for (size_t i = start; i < end; i++)
+                centroidBox = AABB::surrounding_box(centroidBox, triangles[i]->boundingBox());
+
+            Vec3 span = centroidBox.max() - centroidBox.min();
+            int axis = 0;
+            if (span.y() > span.x()) axis = 1;
+            if (span.z() > span[axis]) axis = 2;
+
+            std::sort(triangles.begin() + start, triangles.begin() + end,
+                [axis](const std::shared_ptr<Triangle>& a, const std::shared_ptr<Triangle>& b) {
+                    return a->boundingBox().min()[axis] < b->boundingBox().min()[axis];
+                });
+
+            size_t mid = start + count / 2;
+            _left  = std::make_shared<BVHNode>(triangles, start, mid);
+            _right = std::make_shared<BVHNode>(triangles, mid, end);
+        }
+
+        _box = AABB::surrounding_box(_left->boundingBox(), _right->boundingBox());
+    }
+
+    bool hit(const Ray& ray, double t_min, double t_max, HitRecord& record) const override {
+        if (!_box.hit(ray, t_min, t_max))
+            return false;
+
+        bool hitLeft  = _left->hit(ray, t_min, t_max, record);
+        bool hitRight = _right->hit(ray, t_min, hitLeft ? record.t : t_max, record);
+
+        return hitLeft || hitRight;
+    }
+
+    AABB boundingBox() const override { return _box; }
+
+private:
+    std::shared_ptr<IShape> _left;
+    std::shared_ptr<IShape> _right;
+    AABB _box;
+};

--- a/src/Math/BVHNode.hpp
+++ b/src/Math/BVHNode.hpp
@@ -2,39 +2,38 @@
 
 #include "AABB.hpp"
 #include "../Interfaces/IShape.hpp"
-#include "../plugins/Shapes/Triangle.hpp"
 #include <vector>
 #include <memory>
 #include <algorithm>
 
 class BVHNode : public IShape {
 public:
-    BVHNode(std::vector<std::shared_ptr<Triangle>>& triangles, size_t start, size_t end) {
+    BVHNode(std::vector<std::shared_ptr<IShape>>& shapes, size_t start, size_t end) {
         size_t count = end - start;
 
         if (count == 1) {
-            _left = _right = triangles[start];
+            _left = _right = shapes[start];
         } else if (count == 2) {
-            _left  = triangles[start];
-            _right = triangles[start + 1];
+            _left  = shapes[start];
+            _right = shapes[start + 1];
         } else {
-            AABB centroidBox = triangles[start]->boundingBox();
-            for (size_t i = start; i < end; i++)
-                centroidBox = AABB::surrounding_box(centroidBox, triangles[i]->boundingBox());
+            AABB centroidBox = shapes[start]->boundingBox();
+            for (size_t i = start + 1; i < end; i++)
+                centroidBox = AABB::surrounding_box(centroidBox, shapes[i]->boundingBox());
 
             Vec3 span = centroidBox.max() - centroidBox.min();
             int axis = 0;
             if (span.y() > span.x()) axis = 1;
             if (span.z() > span[axis]) axis = 2;
 
-            std::sort(triangles.begin() + start, triangles.begin() + end,
-                [axis](const std::shared_ptr<Triangle>& a, const std::shared_ptr<Triangle>& b) {
+            std::sort(shapes.begin() + start, shapes.begin() + end,
+                [axis](const std::shared_ptr<IShape>& a, const std::shared_ptr<IShape>& b) {
                     return a->boundingBox().min()[axis] < b->boundingBox().min()[axis];
                 });
 
             size_t mid = start + count / 2;
-            _left  = std::make_shared<BVHNode>(triangles, start, mid);
-            _right = std::make_shared<BVHNode>(triangles, mid, end);
+            _left  = std::make_shared<BVHNode>(shapes, start, mid);
+            _right = std::make_shared<BVHNode>(shapes, mid, end);
         }
 
         _box = AABB::surrounding_box(_left->boundingBox(), _right->boundingBox());

--- a/src/plugins/Shapes/Triangle.hpp
+++ b/src/plugins/Shapes/Triangle.hpp
@@ -9,6 +9,7 @@ public:
     ~Triangle() override = default;
 
     bool hit(const Ray& ray, double t_min, double t_max, HitRecord& record) const override;
+    AABB boundingBox() const override { return _aabb; }
 
 private:
     Vec3 _v0;


### PR DESCRIPTION
## What does this PR do?

Implemented BVHNode class.
takes a vector of triangles:
- if the vector contains one triangle, left & right are the same
- if the vector contains two triangles, left is first, right is second
- if contains more, create a box containing all triangles. find the biggest axis (ex: z). sort triangles on this axis. then recursively create nodes based off half of the triangles (start - mid, mid - end).

## Related issue

Closes #116 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
