### PR TITLE
Feat/watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tests/results/
 *.jpg
 *.jpeg
 !textures/**
+scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ if (WITH_UI)
         src/ui/SceneBrowser.cpp
         src/ui/RenderPanel.cpp
         src/ui/PixelBuffer.cpp
+        src/watcher/FileWatcher.cpp
     )
     target_link_libraries(raytracer PRIVATE sfml-graphics sfml-window sfml-system)
     target_compile_definitions(raytracer PRIVATE WITH_UI)
@@ -181,6 +182,7 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/tests)
             src/external/Roots3And4.c
             src/parsers/ObjParser.cpp
             src/plugins/Shapes/MeshTriangle.cpp
+            src/watcher/FileWatcher.cpp
         )
 
         target_include_directories(run_tests PRIVATE

--- a/src/ui/RenderPanel.cpp
+++ b/src/ui/RenderPanel.cpp
@@ -114,6 +114,9 @@ void RenderPanel::drawRendering(sf::RenderWindow& window) {
     float btnH = std::max(42.f, wh * 0.057f);
     _cancelRect = {cx - btnW / 2.f, wh * 0.74f, btnW, btnH};
     drawButton(window, _cancelRect, "Cancel", COL_CANCEL);
+    
+    // reload indicator
+    drawReloadIndicator(window, ww, wh);
 }
 
 void RenderPanel::drawDone(sf::RenderWindow& window) {
@@ -180,4 +183,24 @@ bool RenderPanel::wasClicked(const sf::Event& event, const sf::RenderWindow& win
     if (event.type != sf::Event::MouseButtonPressed) return false;
     sf::Vector2f pos = window.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
     return rect.contains(pos);
+}
+
+void RenderPanel::drawReloadIndicator(sf::RenderWindow& window, float ww, float wh) {
+    if (!_showReloadIndicator) return;
+    
+    // Draw a pulsing indicator at the top-right corner
+    float indicatorSize = std::clamp(wh * 0.025f, 12.f, 20.f);
+    sf::CircleShape indicator(indicatorSize);
+    indicator.setFillColor(sf::Color::Yellow);
+    indicator.setPosition(ww - indicatorSize * 3.f, indicatorSize);
+    window.draw(indicator);
+    
+    // Label next to indicator
+    unsigned labelSz = static_cast<unsigned>(std::clamp(wh * 0.018f, 11.f, 16.f));
+    sf::Text label("RELOADING", _font, labelSz);
+    label.setFillColor(sf::Color::Yellow);
+    sf::FloatRect lb = label.getLocalBounds();
+    label.setOrigin(lb.left + lb.width, lb.top + lb.height / 2.f);
+    label.setPosition(ww - indicatorSize * 5.5f, indicatorSize * 2.f);
+    window.draw(label);
 }

--- a/src/ui/RenderPanel.hpp
+++ b/src/ui/RenderPanel.hpp
@@ -17,6 +17,9 @@ public:
 
     void drawRendering(sf::RenderWindow& window);
     void drawDone(sf::RenderWindow& window);
+    
+    /// Set whether reload indicator should be shown
+    void setShowReloadIndicator(bool show) { _showReloadIndicator = show; }
 
     // check after handleEvent, cleared by UIApp
     bool wantsCancel() const { return _sigCancel; }
@@ -27,6 +30,8 @@ private:
     void drawButton(sf::RenderWindow& window, sf::FloatRect rect,
                     const std::string& label, sf::Color bg);
     void drawHeader(sf::RenderWindow& window, float ww, float headerH);
+    
+    void drawReloadIndicator(sf::RenderWindow& window, float ww, float wh);
 
     bool wasClicked(const sf::Event& event, const sf::RenderWindow& window,
                     sf::FloatRect rect) const;
@@ -37,6 +42,7 @@ private:
     int         _total = 0;
     bool        _sigCancel = false;
     bool        _sigBack   = false;
+    bool        _showReloadIndicator = false;
 
     sf::FloatRect _cancelRect = {};
     sf::FloatRect _backRect   = {};

--- a/src/ui/UIApp.cpp
+++ b/src/ui/UIApp.cpp
@@ -53,6 +53,8 @@ void UIApp::update() {
 
         case UIState::Rendering:
             _panel.update(_pixelBuffer);
+            checkSceneFileWatch();
+            
             if (_doneFlag.load()) {
                 joinRenderThread();
                 toDone();
@@ -76,6 +78,11 @@ void UIApp::update() {
 void UIApp::draw() {
     _window.clear(sf::Color(22, 22, 30));
 
+    // Update reload indicator for rendering state
+    if (_state == UIState::Rendering) {
+        _panel.setShowReloadIndicator(_showReloadIndicator);
+    }
+
     switch (_state) {
         case UIState::Browser:   _browser.draw(_window);        break;
         case UIState::Rendering: _panel.drawRendering(_window); break;
@@ -91,6 +98,17 @@ void UIApp::toRendering(const std::string& scenePath) {
     _pixelBuffer.init(0, 0);
     _cancelFlag.store(false);
     _doneFlag.store(false);
+    
+    _fileWatcher = std::make_unique<FileWatcher>();
+    try {
+        _fileWatcher->addTargetPath(scenePath);
+        _lastWatchCheck = std::chrono::steady_clock::now();
+        _lastReloadTime = std::chrono::steady_clock::now();
+        _showReloadIndicator = false;
+    } catch (const std::exception& e) {
+        _fileWatcher = nullptr;
+    }
+    
     _state = UIState::Rendering;
     spawnRenderThread();
 }
@@ -118,4 +136,40 @@ void UIApp::spawnRenderThread() {
 void UIApp::joinRenderThread() {
     if (_renderThread.joinable())
         _renderThread.join();
+}
+
+void UIApp::checkSceneFileWatch() {
+    if (!_fileWatcher) return;
+    
+    auto now = std::chrono::steady_clock::now();
+    if (now - _lastWatchCheck < WATCH_THROTTLE) {
+        if (_showReloadIndicator && (now - _lastReloadTime > std::chrono::milliseconds(500))) {
+            _showReloadIndicator = false;
+        }
+        return;
+    }
+    
+    _lastWatchCheck = now;
+    
+    if (!_fileWatcher->watchFileEvents()) { return; }
+    
+    // Debounce: ignore if last reload was too recent (< 500ms)
+    if (now - _lastReloadTime < RELOAD_DEBOUNCE) {
+        _fileWatcher->clearChangeFlag();
+        return;
+    }
+    
+    _lastReloadTime = now;
+    _showReloadIndicator = true;
+    
+    _cancelFlag.store(true);
+    joinRenderThread();
+    
+    // Reset state and restart render
+    _pixelBuffer.init(0, 0);
+    _cancelFlag.store(false);
+    _doneFlag.store(false);
+    _fileWatcher->clearChangeFlag();
+    
+    spawnRenderThread();
 }

--- a/src/ui/UIApp.hpp
+++ b/src/ui/UIApp.hpp
@@ -4,10 +4,13 @@
 #include <atomic>
 #include <string>
 #include <thread>
+#include <memory>
+#include <chrono>
 
 #include "PixelBuffer.hpp"
 #include "RenderPanel.hpp"
 #include "SceneBrowser.hpp"
+#include "watcher/FileWatcher.hpp"
 
 enum class UIState {
     Browser,
@@ -34,6 +37,9 @@ private:
     void toRendering(const std::string& scenePath);
     void toBrowser();
     void toDone();
+    
+    /// Check if scene file has changed and trigger reload if needed
+    void checkSceneFileWatch();
 
     void spawnRenderThread();
     void joinRenderThread();
@@ -50,4 +56,15 @@ private:
     std::thread       _renderThread;
     std::atomic<bool> _cancelFlag{false};
     std::atomic<bool> _doneFlag{false};
+    
+    // File watching for auto-reload
+    std::unique_ptr<FileWatcher> _fileWatcher;
+    std::chrono::steady_clock::time_point _lastWatchCheck;
+    std::chrono::steady_clock::time_point _lastReloadTime;
+    bool _showReloadIndicator{false};
+    
+    /// Throttle file watch checks to once per second
+    static constexpr std::chrono::milliseconds WATCH_THROTTLE{1000};
+    /// Debounce rapid saves: ignore reload if last one was < 500ms ago
+    static constexpr std::chrono::milliseconds RELOAD_DEBOUNCE{500};
 };

--- a/src/watcher/FileWatcher.cpp
+++ b/src/watcher/FileWatcher.cpp
@@ -1,0 +1,63 @@
+
+#include "./FileWatcher.hpp"
+
+#include <linux/limits.h>
+#include <sys/inotify.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <climits>
+
+
+
+FileWatcher::FileWatcher()
+{
+    _iFd = inotify_init1(IN_NONBLOCK);
+    if (_iFd == -1) { throw std::runtime_error("inotify_init1 failed !"); }
+    _wd = 0;
+}
+
+FileWatcher::~FileWatcher()
+{
+    if (_iFd != -1) { close(_iFd); }
+}
+
+void FileWatcher::addTargetPath(const std::string& scene_path)
+{
+    _wd = inotify_add_watch(_iFd, scene_path.c_str(), IN_CLOSE_WRITE | IN_MODIFY);
+    if (_wd == -1) { throw std::runtime_error("inotify_add_watch failed for file: " + scene_path); }
+    _watchedFiles[_wd] = scene_path;
+    _watchedPath = scene_path;
+}
+
+bool FileWatcher::watchFileEvents()
+{
+    const ssize_t buf_size = (sizeof(const struct inotify_event) + NAME_MAX + 1);
+    char BUFFER[buf_size];
+    memset(BUFFER, 0, buf_size);
+    ssize_t read_size = 0;
+    const struct inotify_event *ievent;
+
+    read_size = read(_iFd, BUFFER, buf_size);
+    if (read_size == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return _fileChanged;
+        }
+
+        throw std::runtime_error("Read failed on fd: " + std::to_string(_iFd));
+    }
+
+    if (read_size <= 0) { return _fileChanged; }
+    
+    for (char *read_ptr = BUFFER; read_ptr < BUFFER + read_size;
+            read_ptr += sizeof(struct inotify_event) + ievent->len) {
+        ievent = (const struct inotify_event *) read_ptr;
+
+        if (ievent->mask & IN_MODIFY || (ievent->mask & IN_CLOSE_WRITE)) { _fileChanged = true; }
+    }
+    
+    return _fileChanged;
+}

--- a/src/watcher/FileWatcher.hpp
+++ b/src/watcher/FileWatcher.hpp
@@ -1,0 +1,35 @@
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <atomic>
+
+
+
+
+class FileWatcher 
+{
+    public:
+        FileWatcher();
+        ~FileWatcher();
+        
+        void addTargetPath(const std::string& scene_path);
+        
+        /// Check for file change events. Returns true if file was modified.
+        /// Non-blocking inotify read with IN_NONBLOCK mode
+        bool watchFileEvents();
+        
+        /// Clear the change flag (call after handling the change)
+        void clearChangeFlag() { _fileChanged = false; }
+        
+        /// Get the watched file path
+        std::string getWatchedPath() const { return _watchedPath; }
+
+    private:
+        int _iFd;
+        int _wd;
+        std::map<int, std::string> _watchedFiles;
+        std::string _watchedPath;
+        std::atomic<bool> _fileChanged{false};
+};

--- a/tests/test_filewatcher.cpp
+++ b/tests/test_filewatcher.cpp
@@ -1,0 +1,60 @@
+#include <criterion/criterion.h>
+#include <fstream>
+#include <sstream>
+#include <thread>
+#include <chrono>
+#include <filesystem>
+#include "../src/watcher/FileWatcher.hpp"
+
+Test(FileWatcher, construction)
+{
+    FileWatcher watcher;
+    cr_assert_not_null(&watcher);
+}
+
+Test(FileWatcher, add_target_path)
+{
+    std::string test_file = "/tmp/test_filewatcher_file.txt";
+    std::ofstream f(test_file);
+    f << "test";
+    f.close();
+
+    FileWatcher watcher;
+    cr_assert_no_throw(watcher.addTargetPath(test_file));
+
+    std::filesystem::remove(test_file);
+}
+
+Test(FileWatcher, add_invalid_path)
+{
+    FileWatcher watcher;
+    cr_assert_throw(watcher.addTargetPath("/nonexistent/path/to/file.txt"), std::runtime_error);
+}
+
+Test(FileWatcher, process_events_on_file_change)
+{
+    std::string test_file = "/tmp/test_filewatcher_change.txt";
+    std::ofstream f(test_file);
+    f << "initial content";
+    f.close();
+
+    FileWatcher watcher;
+    watcher.addTargetPath(test_file);
+
+    // Give the watcher a moment to initialize
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Modify the file
+    std::ofstream f2(test_file, std::ios::app);
+    f2 << "\nmodified content";
+    f2.close();
+
+    // Give the filesystem time to generate the event
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Check for changes (should detect the modification)
+    cr_assert(watcher.watchFileEvents());
+
+    // Cleanup
+    std::filesystem::remove(test_file);
+}


### PR DESCRIPTION
## FIXES

Closes #147 

## Description

Watch the active scene file for changes and automatically re-trigger rendering when the file is saved.

## Dependencies

-   Requires [feat(ui): SFML scaffolding + scene browser #144](https://github.com/louisbgl/raytracer-mirror/issues/144) (SFML scaffolding + scene browser)

## How

-   Implemented a  file watcher that targets the given scene.txt using `inotify in **non-blocking mode**.
-  Events are checked in `UIApp:update()` using `checkSceneFileWatch()`who handles all the watching logic
- Encapsulation of the `linux/inotify.h`header file.
- When the scene is modified the current rendering process is killed and we start it over    
 - Show visual indicator in UI when reload is triggered
 - Avoids chained refreshing using by comparing last change and current change time.


## Validation

-  [X] Code compiles without warnings
-  [X] Tests pass (`cmake --build build --target tests_run`)
-  [X] No binary/object files committed