### PR TITLE
Refactor/move material to ashape

### DIFF
--- a/src/core/AShape.cpp
+++ b/src/core/AShape.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
-AShape::AShape(Vec3 rotation, Vec3 translation, Vec3 scale) {
+AShape::AShape(Vec3 rotation, Vec3 translation, Vec3 scale, std::shared_ptr<IMaterial> material) : _material(material) {
     _transform =
         Matrix4x4::translate(translation) * Matrix4x4::rotate(rotation) * Matrix4x4::scale(scale);
     _inverseTransform = _transform.inverse();
@@ -11,7 +11,7 @@ AShape::AShape(Vec3 rotation, Vec3 translation, Vec3 scale) {
     _aabbNeedsUpdate = true;
 }
 
-AShape::AShape(const Matrix4x4& transform) {
+AShape::AShape(const Matrix4x4& transform, std::shared_ptr<IMaterial> material) : _material(material) {
     _transform = transform;
     _inverseTransform = _transform.inverse();
     _normalTransform = _inverseTransform.transposed();
@@ -77,7 +77,7 @@ HitRecord AShape::localToWorld(const HitRecord& local, const Ray& worldRay) cons
     Vec3 worldNormal = _normalTransform.transformDirection(local.normal);
 
     worldNormal = normalize(worldNormal);
-    HitRecord world(worldPoint, worldNormal, local.t, local.front_face, local.material);
+    HitRecord world(worldPoint, worldNormal, local.t, local.front_face, _material);
 
     world.u = local.u;
     world.v = local.v;

--- a/src/core/AShape.hpp
+++ b/src/core/AShape.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Interfaces/IBoundable.hpp"
+#include "../Interfaces/IMaterial.hpp"
 #include "../Math/AABB.hpp"
 #include "../Math/Matrix4x4.hpp"
 
@@ -12,6 +13,7 @@
  *   - AABB-based early ray rejection
  *   - Range validation (t_min/t_max)
  *   - Ray space conversions (world ↔ local)
+ *   - Have a protected std::shared_ptr<IMaterial> _material
  *
  * What you implement:
  *   - hitLocal(): Ray intersection assuming shape is at origin (0,0,0) and axis-aligned
@@ -28,14 +30,16 @@ public:
      * @param rotation Euler angles in degrees (rx, ry, rz) - ZYX convention
      * @param translation Position in world space (x, y, z)
      * @param scale Scale factors for each axis (x, y, z)
+     * @param material The material for the shape.
      */
-    AShape(Vec3 rotation, Vec3 translation, Vec3 scale);
+    AShape(Vec3 rotation, Vec3 translation, Vec3 scale, std::shared_ptr<IMaterial> material);
 
     /**
      * @brief Constructor for directly providing a transformation matrix.
      * @param transform The world transformation matrix to apply to the shape.
+     * @param material The material for the shape.
      */
-    AShape(const Matrix4x4& transform);
+    AShape(const Matrix4x4& transform, std::shared_ptr<IMaterial> material);
 
     /**
      * @brief [FINAL] Full intersection pipeline: AABB check → transform to local → hitLocal() → transform to world → range check
@@ -55,6 +59,8 @@ public:
     virtual AABB computeLocalAABB() const = 0;
 
 protected:
+    std::shared_ptr<IMaterial> _material;
+
     void updateWorldAABB();
 
 private:

--- a/src/plugins/Shapes/Box.cpp
+++ b/src/plugins/Shapes/Box.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 
 Box::Box(Vec3 rotation, Vec3 translation, Vec3 scale, double width, double height, double depth, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _width(width), _height(height), _depth(depth), _material(material) {}
+    : AShape(rotation, translation, scale, material), _width(width), _height(height), _depth(depth) {}
 
 bool Box::hitLocal(const Ray& ray, HitRecord& record) const {
     Vec3 min_corner(-_width / 2.0, -_height / 2.0, -_depth / 2.0);

--- a/src/plugins/Shapes/Box.hpp
+++ b/src/plugins/Shapes/Box.hpp
@@ -14,5 +14,4 @@ private:
     double _width;
     double _height;
     double _depth;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/LimitedCone.cpp
+++ b/src/plugins/Shapes/LimitedCone.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 LimitedCone::LimitedCone(Vec3 rotation, Vec3 translation, Vec3 scale, double radius, double height, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _radius(radius), _height(height), _material(material) {}
+    : AShape(rotation, translation, scale, material), _radius(radius), _height(height) {}
 
 bool LimitedCone::hitLocal(const Ray& ray, HitRecord& record) const {
     double closest_t = std::numeric_limits<double>::infinity();

--- a/src/plugins/Shapes/LimitedCone.hpp
+++ b/src/plugins/Shapes/LimitedCone.hpp
@@ -15,5 +15,4 @@ private:
 
     double _radius;
     double _height;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/LimitedCylinder.cpp
+++ b/src/plugins/Shapes/LimitedCylinder.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 LimitedCylinder::LimitedCylinder(Vec3 rotation, Vec3 translation, Vec3 scale, double radius, double height, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _radius(radius), _height(height), _material(material) {}
+    : AShape(rotation, translation, scale, material), _radius(radius), _height(height) {}
 
 bool LimitedCylinder::hitLocal(const Ray& ray, HitRecord& record) const {
     double closest_t = std::numeric_limits<double>::infinity();

--- a/src/plugins/Shapes/LimitedCylinder.hpp
+++ b/src/plugins/Shapes/LimitedCylinder.hpp
@@ -23,5 +23,4 @@ private:
 
     double _radius;
     double _height;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/LimitedHourglass.cpp
+++ b/src/plugins/Shapes/LimitedHourglass.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 LimitedHourglass::LimitedHourglass(Vec3 rotation, Vec3 translation, Vec3 scale, double radius, double height, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _radius(radius), _height(height), _material(material) {}
+    : AShape(rotation, translation, scale, material), _radius(radius), _height(height) {}
 
 bool LimitedHourglass::hitLocal(const Ray& ray, HitRecord& record) const {
     double closest_t = std::numeric_limits<double>::infinity();

--- a/src/plugins/Shapes/LimitedHourglass.hpp
+++ b/src/plugins/Shapes/LimitedHourglass.hpp
@@ -15,5 +15,4 @@ private:
 
     double _radius;
     double _height;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/Mesh.cpp
+++ b/src/plugins/Shapes/Mesh.cpp
@@ -4,7 +4,7 @@
 #include <stdexcept>
 
 Mesh::Mesh(const std::string& filename, Vec3 rotation, Vec3 translation, Vec3 scale, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale)
+    : AShape(rotation, translation, scale, material)
 {
     ObjParser parser;
     auto shapes = parser.parse(filename, material);

--- a/src/plugins/Shapes/Rectangle.cpp
+++ b/src/plugins/Shapes/Rectangle.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 
 Rectangle::Rectangle(Vec3 rotation, Vec3 translation, Vec3 scale, double width, double height, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _width(width), _height(height), _material(material) {}
+    : AShape(rotation, translation, scale, material), _width(width), _height(height) {}
 
 bool Rectangle::hitLocal(const Ray& ray, HitRecord& record) const {
     // Rectangle in XY plane at z=0, centered at origin

--- a/src/plugins/Shapes/Rectangle.hpp
+++ b/src/plugins/Shapes/Rectangle.hpp
@@ -13,5 +13,4 @@ public:
 private:
     double _width;
     double _height;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/Sphere.cpp
+++ b/src/plugins/Shapes/Sphere.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 Sphere::Sphere(Vec3 rotation, Vec3 translation, Vec3 scale, double radius, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _radius(radius), _material(material) {}
+    : AShape(rotation, translation, scale, material), _radius(radius) {}
 
 bool Sphere::hitLocal(const Ray& ray, HitRecord& record) const {
     Vec3 oc = ray.origin();

--- a/src/plugins/Shapes/Sphere.hpp
+++ b/src/plugins/Shapes/Sphere.hpp
@@ -12,5 +12,4 @@ public:
 
 private:
     double _radius;
-    std::shared_ptr<IMaterial> _material;
 };

--- a/src/plugins/Shapes/Tanglecube.cpp
+++ b/src/plugins/Shapes/Tanglecube.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 Tanglecube::Tanglecube(Vec3 rotation, Vec3 translation, double scale, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, Vec3(1, 1, 1)), _scale(scale), _material(material) {}
+    : AShape(rotation, translation, Vec3(1, 1, 1), material), _scale(scale) {}
 
 double Tanglecube::evaluate(double x, double y, double z) const {
     double x_scaled = x / _scale;

--- a/src/plugins/Shapes/Tanglecube.hpp
+++ b/src/plugins/Shapes/Tanglecube.hpp
@@ -12,7 +12,6 @@ public:
 
 private:
     double _scale;
-    std::shared_ptr<IMaterial> _material;
 
     double evaluate(double x, double y, double z) const;
     Vec3 gradient(double x, double y, double z) const;

--- a/src/plugins/Shapes/Torus.cpp
+++ b/src/plugins/Shapes/Torus.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 Torus::Torus(Vec3 rotation, Vec3 translation, Vec3 scale, double majorRadius, double minorRadius, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale), _majorRadius(majorRadius), _minorRadius(minorRadius), _material(material) {}
+    : AShape(rotation, translation, scale, material), _majorRadius(majorRadius), _minorRadius(minorRadius) {}
 
 bool Torus::hitLocal(const Ray& ray, HitRecord& record) const {
     Vec3 oc = ray.origin();

--- a/src/plugins/Shapes/Torus.hpp
+++ b/src/plugins/Shapes/Torus.hpp
@@ -13,7 +13,6 @@ public:
 private:
     double _majorRadius;
     double _minorRadius;
-    std::shared_ptr<IMaterial> _material;
 
     Vec3 computeNormal(const Vec3& point) const;
 };

--- a/src/plugins/Shapes/Triangle.cpp
+++ b/src/plugins/Shapes/Triangle.cpp
@@ -2,12 +2,11 @@
 #include "../PluginMetadata.hpp"
 
 Triangle::Triangle(Vec3 v0, Vec3 v1, Vec3 v2, Vec3 rotation, Vec3 translation, Vec3 scale, std::shared_ptr<IMaterial> material)
-    : AShape(rotation, translation, scale),
+    : AShape(rotation, translation, scale, material),
       _v0(v0),
       _edge1(v1 - v0),
       _edge2(v2 - v0),
-      _normal(normalize(cross(_edge1, _edge2))),
-      _material(material)
+      _normal(normalize(cross(_edge1, _edge2)))
 {
 }
 

--- a/src/plugins/Shapes/Triangle.hpp
+++ b/src/plugins/Shapes/Triangle.hpp
@@ -15,6 +15,5 @@ private:
     Vec3 _edge1;
     Vec3 _edge2;
     Vec3 _normal;
-    std::shared_ptr<IMaterial> _material;
     double _epsilon = 1e-8;
 };


### PR DESCRIPTION
## What does this PR do?

Move std::shared_ptr<IMaterial> _material definition to AShape.hpp

## Related issue

Closes #174 

## Checklist

- [x] Code compiles without warnings
- [x] Tests pass (`cmake --build build --target tests_run`)
- [x] No binary/object files committed
